### PR TITLE
Clean up unused imports

### DIFF
--- a/lib/db/database_helper.dart
+++ b/lib/db/database_helper.dart
@@ -3,7 +3,6 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 import '../models/book.dart';
 import '../models/review.dart';
-import 'dart:io';
 
 class DatabaseHelper {
   static final DatabaseHelper instance = DatabaseHelper._();


### PR DESCRIPTION
## Summary
- drop unused `dart:io` import from DatabaseHelper

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686feb96686c83338878fa83ab364680