### PR TITLE
Expand gitignore for platform and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ pubspec.lock
 android/.gradle/
 android/app/build/
 ios/Pods/
+
+# Standard Flutter platform directories
+android/
+ios/
+linux/
+macos/
+windows/
+
+# IDE and editor settings
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- ignore Flutter platform folders: android, ios, linux, macos, and windows
- ignore IDE folders: .vscode and .idea

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686feb9ae100833398a3421f4e1225b3