### PR TITLE
Add like button for reviews

### DIFF
--- a/lib/db/database_helper.dart
+++ b/lib/db/database_helper.dart
@@ -17,7 +17,12 @@ class DatabaseHelper {
   Future<Database> _initDb() async {
     final directory = await getApplicationDocumentsDirectory();
     final path = join(directory.path, 'rating_roost.db');
-    return await openDatabase(path, version: 1, onCreate: _onCreate);
+    return await openDatabase(
+      path,
+      version: 2,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
+    );
   }
 
   Future<void> _onCreate(Database db, int version) async {
@@ -32,9 +37,18 @@ class DatabaseHelper {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         bookId INTEGER NOT NULL,
         content TEXT NOT NULL,
+        isLiked INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY(bookId) REFERENCES books(id) ON DELETE CASCADE
       )
     ''');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute(
+        'ALTER TABLE reviews ADD COLUMN isLiked INTEGER NOT NULL DEFAULT 0',
+      );
+    }
   }
 
   Future<int> insertBook(Book book) async {

--- a/lib/models/review.dart
+++ b/lib/models/review.dart
@@ -2,13 +2,15 @@ class Review {
   final int? id;
   final int bookId;
   final String content;
+  final bool isLiked;
 
-  Review({this.id, required this.bookId, required this.content});
+  Review({this.id, required this.bookId, required this.content, this.isLiked = false});
 
   Map<String, dynamic> toMap() {
     final map = <String, dynamic>{
       'bookId': bookId,
       'content': content,
+      'isLiked': isLiked ? 1 : 0,
     };
     if (id != null) map['id'] = id;
     return map;
@@ -19,6 +21,7 @@ class Review {
       id: map['id'] as int?,
       bookId: map['bookId'] as int,
       content: map['content'] as String,
+      isLiked: (map['isLiked'] ?? 0) == 1,
     );
   }
 }

--- a/lib/screens/review_form_screen.dart
+++ b/lib/screens/review_form_screen.dart
@@ -32,6 +32,7 @@ class _ReviewFormScreenState extends State<ReviewFormScreen> {
           id: widget.review!.id,
           bookId: widget.book.id!,
           content: _controller.text,
+          isLiked: widget.review!.isLiked,
         ),
       );
     }

--- a/lib/screens/review_list_screen.dart
+++ b/lib/screens/review_list_screen.dart
@@ -53,6 +53,17 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
     _loadReviews();
   }
 
+  void _toggleLike(Review review) async {
+    final updated = Review(
+      id: review.id,
+      bookId: review.bookId,
+      content: review.content,
+      isLiked: !review.isLiked,
+    );
+    await DatabaseHelper.instance.updateReview(updated);
+    _loadReviews();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -66,6 +77,15 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                IconButton(
+                  icon: Icon(
+                    review.isLiked
+                        ? Icons.thumb_up
+                        : Icons.thumb_up_off_alt,
+                    color: review.isLiked ? Colors.blue : null,
+                  ),
+                  onPressed: () => _toggleLike(review),
+                ),
                 IconButton(
                   icon: const Icon(Icons.edit),
                   onPressed: () => _editReview(review),


### PR DESCRIPTION
## Summary
- store like state for reviews and persist in database
- allow toggling likes from the review list with a new icon button
- keep existing like status when editing a review

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c195a9e48333a6a0944ce3d41461